### PR TITLE
Respect custom waitStrategy for InfluxDB

### DIFF
--- a/modules/influxdb/influxdb_test.go
+++ b/modules/influxdb/influxdb_test.go
@@ -3,7 +3,6 @@ package influxdb_test
 import (
 	"context"
 	"encoding/json"
-	"github.com/testcontainers/testcontainers-go/wait"
 	"net/http"
 	"path/filepath"
 	"testing"
@@ -15,6 +14,7 @@ import (
 
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/modules/influxdb"
+	"github.com/testcontainers/testcontainers-go/wait"
 )
 
 func TestV1Container(t *testing.T) {


### PR DESCRIPTION
<!-- **Type of change**  
Please label this PR with one of the existing labels, depending on the scope of your change. -->

## What does this PR do?

The purpose of this PR is to respect the provided `waitStrategy` for the InfluxDB container, rather than overriding it by default. This change allows the use of a custom `waitStrategy` when specified; if none is provided, the default `waitStrategy` will be applied, maintaining the same configuration as before this modification.

<!-- **Mandatory**  
Explain here the changes you made in the PR. Please provide details on the patterns used, algorithms implemented, and design architecture. -->

## Why is it important?

In the current implementation, it's not possible to use a custom `waitStrategy` and in my case the default strategy marks the container as ready too early. The container is still not ready to receive writes. Customizing the `waitStrategy` to check the `/health` status solved this issue. Example log output when container is not ready yet:

```
2024/10/22 10:38:54 ✅ Container started: d5d6612ccd27
2024/10/22 10:38:54 ⏳ Waiting for container id d5d6612ccd27 image: influxdb:2.0.7. Waiting for: &{timeout:<nil> Log:Listening log_id=[0-9a-zA-Z_~]+ service=tcp-listener transport=http IsRegexp:true Occurrence:1 PollInterval:100ms}
2024/10/22 10:39:04 🔔 Container is ready: d5d6612ccd27
2024-10-22T10:39:23.408+07:00|2|ERROR||,,,testing-invalid|9469|goroutine:1783|internal/runner.go:93|Post "http://localhost:49155/api/v2/write?bucket=lp-batch&org=influxdata&precision=ns": read tcp [::1]:43726->[::1]:49155: read: connection reset by peer
2024/10/22 10:39:24 [E]! Write error: Post "http://localhost:49155/api/v2/write?bucket=lp-batch&org=influxdata&precision=ns": read tcp [::1]:55852->[::1]:49155: read: connection reset by peer
2024/10/22 10:39:24 unable to send metrics to InfluxDB. err=Post "http://localhost:49155/api/v2/write?bucket=lp-batch&org=influxdata&precision=ns": read tcp [::1]:55852->[::1]:49155: read: connection reset by peer
```

A different strategy could be employed, for example, to verify if InfluxDB is `ready for queries and writes` as you can see on below health check response:
```json
{
  "name": "influxdb",
  "message": "ready for queries and writes",
  "status": "pass",
  "checks": [],
  "version": "2.0.7",
  "commit": "2a45f0c037"
}
```


## Related issues
- None

## How to test this PR

I have added a test that uses a custom `waitStrategy` to verify this behavior.